### PR TITLE
Fix medline fetch and refresh 404

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { HashRouter, Routes, Route } from 'react-router-dom';
 import DashboardPage from './pages/DashboardPage';
 import MedicationsPage from './pages/MedicationsPage';
 import LogEntryPage from './pages/LogEntryPage';
@@ -14,7 +14,7 @@ import TermsOfService from './components/shared/TOS';
 export default function App() {
   return (
     <div className="min-h-screen bg-[#A3B5AC] text-gray-800 font-sans antialiased">
-      <BrowserRouter>
+      <HashRouter>
         <Header />
 
         <Routes>
@@ -30,7 +30,7 @@ export default function App() {
           <Route path="/terms" element={<TermsOfService />} />
         </Routes>
         <Footer />
-      </BrowserRouter>
+      </HashRouter>
     </div>
   );
 }

--- a/src/components/medications/AddMedicationForm.jsx
+++ b/src/components/medications/AddMedicationForm.jsx
@@ -127,6 +127,9 @@ export default function AddMedicationForm({ onClose, onSubmit }) {
           let fetchedSuggestions = [];
           try {
             fetchedSuggestions = await fetchMedicationSuggestions(value);
+            if (fetchedSuggestions && fetchedSuggestions.length > 0) {
+              setMedlineError(false);
+            }
           } catch (err) {
             // handle fetch error
             console.error('Error fetching suggestions:', err);

--- a/src/services/medication-autofill/medlineService.js
+++ b/src/services/medication-autofill/medlineService.js
@@ -1,21 +1,22 @@
 // Fetch medication suggestions from MedlinePlus Connect API
 // Returns: Array of { commonName, medicalName }
 export async function fetchMedlineSuggestions(query) {
-  const apiUrl = `/api/medline-suggestions?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.dn=${encodeURIComponent(query)}&knowledgeResponseType=application/json`;
+  const apiUrl = `https://connect.medlineplus.gov/application?mainSearchCriteria.v.cs=2.16.840.1.113883.6.88&mainSearchCriteria.v.dn=${encodeURIComponent(
+    query,
+  )}&knowledgeResponseType=application/json`;
   try {
     const response = await fetch(apiUrl, {
       headers: {
         Accept: 'application/json',
       },
     });
+    if (response.status === 404) {
+      return [];
+    }
     if (!response.ok) {
       throw new Error(`API error: ${response.status}`);
     }
     const data = await response.json();
-
-    // Log the raw data to see what structure you get
-    console.log('Medline API raw response:', data);
-    console.log('Medline API raw feed:', JSON.stringify(data.feed, null, 2));
 
     // Attempt to extract suggestions from MedlinePlus Connect response format
     if (data && data.feed && Array.isArray(data.feed.entry)) {


### PR DESCRIPTION
## Summary
- use HashRouter to prevent 404 on refresh
- handle MedlinePlus 404 response gracefully and remove debug logs
- reset medline error state when suggestions load

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874e10103bc832c8600e8e9ea32d7c7